### PR TITLE
Update importsNotUsedAsValues value

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
-    "importsNotUsedAsValues": "preserve",
+    "importsNotUsedAsValues": "remove",
     "baseUrl": ".",
     "types": [
       "webpack-env",


### PR DESCRIPTION
This PR updates the `importsNotUsedAsValues` value to its default `"remove"` as `"preserve"` is not supported by the Vercel platform.